### PR TITLE
Update setup-ruby action

### DIFF
--- a/.github/workflows/fire.yml
+++ b/.github/workflows/fire.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Setup Ruby 2.7
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.x
 


### PR DESCRIPTION
Current workflow were failed due to the deprecation of [actions/setup-ruby@v1](https://github.com/actions/setup-ruby). The error located at <https://github.com/y-o0/damdata/actions/runs/3977574868/jobs/6818822427>.

It was replaced by [ruby/setup-ruby](https://github.com/ruby/setup-ruby).