### PR TITLE
Match Version Syntax

### DIFF
--- a/.github/workflows/fire.yml
+++ b/.github/workflows/fire.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: 2.7
 
       - name: execute
         env:


### PR DESCRIPTION
According [Version Syntax](https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby#supported-version-syntax), replaced `ruby-version: 2.7.x` with `ruby-version: 2.7`.